### PR TITLE
trying to resolve eXist 5.2.0 errors with map function

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -54,8 +54,8 @@ declare function app:get-work($node as node(), $model as map(*)) {
                 ('No record found. ',xmldb:encode-uri($config:data-root || "/" || request:get-parameter('doc', '') || '.xml'))
                 (: Debugging ('No record found. ',xmldb:encode-uri($config:data-root || "/" || request:get-parameter('doc', '') || '.xml')):)
                (:response:redirect-to(xs:anyURI(concat($config:nav-base, '/404.html'))):)
-            else map {"hits" := $rec }
-    else map {"hits" := 'Output plain HTML page'}
+            else map {"hits" : $rec }
+    else map {"hits" : 'Output plain HTML page'}
 };
 
 (:~
@@ -360,7 +360,7 @@ declare function app:get-wiki($node as node(), $model as map(*), $wiki-uri as xs
             concat($wiki-uri, request:get-parameter('wiki-page', ''))
         else $wiki-uri
     let $wiki-data := app:wiki-rest-request($uri)
-    return map {"hits" := $wiki-data}
+    return map {"hits" : $wiki-data}
 };
 
 (:~

--- a/modules/lib/get-related.xqm
+++ b/modules/lib/get-related.xqm
@@ -11,6 +11,9 @@ import module namespace functx="http://www.functx.com";
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace html="http://www.w3.org/1999/xhtml";
 
+(: for testing to keep eXist from breaking :)
+declare namespace map="http://www.w3.org/2005/xpath-functions/map";
+
 declare function rel:get-related($uris as xs:string?) as map(xs:string, function(*)){
     map:new(
         for $uri at $i in tokenize($uris,' ')
@@ -310,7 +313,7 @@ let $data :=
     where $sort != ''
     order by $sort
     return concat($id, 'headword:=', $headword)
-return  map { "cited" := $data}    
+return  map { "cited" : $data}    
 };
 
 (:~ 

--- a/modules/search/search.xqm
+++ b/modules/search/search.xqm
@@ -63,8 +63,8 @@ declare %templates:wrap function search:search-data($node as node(), $model as m
             let $hits := data:search($collection, $search-string, $sort-element)
             return
                 map {
-                        "hits" := $hits,
-                        "query" := $queryExpr
+                        "hits" : $hits,
+                        "query" : $queryExpr
                     } 
 };
 


### PR DESCRIPTION
- `:=` no longer allowed for map, only `:` according to eXist 5.2.0
- `map:` calls in lib/get-related.xqm  reporting no namespace

Even with the above changes, I'm getting the below error: 

```
<exception>
<path>/db/apps/usaybia/modules/view.xql</path>
<message>
err:XPST0017 error found while loading module app: Error while loading module app.xql: error found while loading module rel: Error while loading module lib/get-related.xqm: Function map:new() is not defined in module namespace: http://www.w3.org/2005/xpath-functions/map [at line 18, column 5]
</message>
</exception>
```